### PR TITLE
Setup web form sale order

### DIFF
--- a/app/channels/dashboard_channel.rb
+++ b/app/channels/dashboard_channel.rb
@@ -1,5 +1,5 @@
 class DashboardChannel < ApplicationCable::Channel
   def subscribed
-    stream_from "line_chatbot"
+    stream_from "dashboard"
   end
 end

--- a/app/controllers/linebot_controller.rb
+++ b/app/controllers/linebot_controller.rb
@@ -44,12 +44,6 @@ class LinebotController < ApplicationController
     ActionCable.server.broadcast(
       "line_chatbot",
       data
-      # {
-      #   amount: capture.amount,
-      #   product: capture.product,
-      #   saleChannel: capture.sale_channel,
-      #   salePersonLineId: capture.sale_person_line_id
-      # }
     )
   end
 end

--- a/app/controllers/sale_orders_controller.rb
+++ b/app/controllers/sale_orders_controller.rb
@@ -12,13 +12,13 @@ class SaleOrdersController < ApplicationController
       capture.broadcast_to_dashboard
       redirect_to root_path, status: :see_other
     else
-      # render turbo_stream: [
-      #   turbo_stream.replace(
-      #     "error-message",
-      #     partial: "error/error_message",
-      #     locals: {object: capture}
-      #   )
-      # ]
+      render turbo_stream: [
+        turbo_stream.replace(
+          "error-message",
+          partial: "sale_orders/error_message",
+          locals: {object: capture}
+        )
+      ]
     end
   end
 
@@ -43,7 +43,6 @@ class SaleOrdersController < ApplicationController
   end
 
   def match_with_line_id
-    debugger
     line_user_id = params[:sale][:line_user_id]
     return false if line_user_id.blank?
 

--- a/app/controllers/sale_orders_controller.rb
+++ b/app/controllers/sale_orders_controller.rb
@@ -1,0 +1,53 @@
+class SaleOrdersController < ApplicationController
+  before_action :authenticate_sale_person
+
+  def new
+  end
+
+  def create
+    capture = WebMessageCapture.new(current_user, sale_order_params)
+
+    if capture.valid?
+      capture.create_sale!
+      capture.broadcast_to_dashboard
+      redirect_to root_path, status: :see_other
+    else
+      # render turbo_stream: [
+      #   turbo_stream.replace(
+      #     "error-message",
+      #     partial: "error/error_message",
+      #     locals: {object: capture}
+      #   )
+      # ]
+    end
+  end
+
+  private
+
+  def sale_order_params
+    params.require(:sale).permit(
+      :product_code,
+      :channel_code,
+      :amount
+    )
+  end
+
+  def authenticate_sale_person
+    # user must be match one of either cases
+    # - a `current_user` who already login from web
+    # - a request with params[:line_id] and this line_id match
+    # with one of the user record in database
+    unless authenticate_user! || match_with_line_id
+      render json: "not authorized", status: :unauthorized
+    end
+  end
+
+  def match_with_line_id
+    debugger
+    line_user_id = params[:sale][:line_user_id]
+    return false if line_user_id.blank?
+
+    user_from_line_id = User.find_by_line_user_id line_user_id
+    current_user = user_from_line_id
+  end
+end

--- a/app/javascript/channels/dashboard_channel.js
+++ b/app/javascript/channels/dashboard_channel.js
@@ -2,7 +2,7 @@ import consumer from "channels/consumer"
 
 let dashboard = document.getElementById("dashboard")
 if(dashboard != null) {
-  consumer.subscriptions.create({channel: "DashboardChannel", room: "line_chatbot"}, {
+  consumer.subscriptions.create({channel: "DashboardChannel", room: "dashboard"}, {
     initialized() {
     },
     connected() {

--- a/app/models/sale.rb
+++ b/app/models/sale.rb
@@ -1,4 +1,6 @@
 class Sale < ApplicationRecord
+  belongs_to :user
+
   scope :total_amount, -> { sum(:amount) }
   scope :dashboard_data, -> {
     {
@@ -7,4 +9,6 @@ class Sale < ApplicationRecord
       amount_by_channel: Sale.group(:channel_code).sum(:amount)
     }
   }
+
+  validates :amount, numericality: { only_integer: true, greater_than: 0 }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,7 +6,10 @@ class User < ApplicationRecord
 
   enum role: {user: "user", admin: "admin"}
 
+  has_many :sales
+
   validates :email, uniqueness: true
 
   scope :users, -> { where(role: "user") }
+
 end

--- a/app/services/web_message_capture.rb
+++ b/app/services/web_message_capture.rb
@@ -32,9 +32,7 @@ class WebMessageCapture
     if valid?
       # TODO
       # This broadcast should be handle by a background job
-      #
-      puts "\nwill broadcast to dashbard channel"
-      # ActionCable.server.broadcast("line_chatbot", {value: value})
+      ActionCable.server.broadcast("dashboard", Sale.dashboard_data)
     end
   end
 end

--- a/app/services/web_message_capture.rb
+++ b/app/services/web_message_capture.rb
@@ -1,29 +1,31 @@
 class WebMessageCapture
   attr_reader :current_user
-  attr_reader :amount, :product_code, :channel_code, :error
+  attr_reader :amount, :product_code, :channel_code
 
   def initialize(current_user, params)
     @current_user = current_user
     @amount = params[:amount]
     @product_code = params[:product_code]
     @channel_code = params[:channel_code]
-  end
 
-  def valid?
-    @error.blank? and current_user.present?
-  end
-
-  def create_sale!
-    new_sale = Sale.create(
+    @new_sale = Sale.new(
       user: current_user,
       amount: amount,
       product_code: product_code,
       channel_code: channel_code
     )
+  end
 
-    unless new_sale
-      @error = sale.errors.full_messages.join(",")
-    end
+  def valid?
+    current_user.present? and @new_sale.valid?
+  end
+
+  def create_sale!
+    @new_sale.save!
+  end
+
+  def error
+    @new_sale.errors.full_messages.join(",") unless valid?
   end
 
   def broadcast_to_dashboard

--- a/app/services/web_message_capture.rb
+++ b/app/services/web_message_capture.rb
@@ -1,0 +1,38 @@
+class WebMessageCapture
+  attr_reader :current_user
+  attr_reader :amount, :product_code, :channel_code, :error
+
+  def initialize(current_user, params)
+    @current_user = current_user
+    @amount = params[:amount]
+    @product_code = params[:product_code]
+    @channel_code = params[:channel_code]
+  end
+
+  def valid?
+    @error.blank? and current_user.present?
+  end
+
+  def create_sale!
+    new_sale = Sale.create(
+      user: current_user,
+      amount: amount,
+      product_code: product_code,
+      channel_code: channel_code
+    )
+
+    unless new_sale
+      @error = sale.errors.full_messages.join(",")
+    end
+  end
+
+  def broadcast_to_dashboard
+    if valid?
+      # TODO
+      # This broadcast should be handle by a background job
+      #
+      puts "\nwill broadcast to dashbard channel"
+      # ActionCable.server.broadcast("line_chatbot", {value: value})
+    end
+  end
+end

--- a/app/views/sale_orders/_error_message.html.erb
+++ b/app/views/sale_orders/_error_message.html.erb
@@ -1,0 +1,4 @@
+<div id="error-message" class="text-sm text-red-500 px-4 py-2 border rounded">
+  <%= object.error %>
+</div>
+

--- a/app/views/sale_orders/new.html.erb
+++ b/app/views/sale_orders/new.html.erb
@@ -1,0 +1,27 @@
+<section id="web-form" class="p-4">
+  <h1 class="text-2xl font-semibold mb-4">Sale order</h1>
+  <%= form_with model: Sale.new, url: sale_orders_path, method: :post do |form| %>
+    <div class="field mb-4">
+      <%= form.label :product_code, class: "block text-sm text-gray-500 mb-1" %>
+      <%= form.select :product_code, Product.all.pluck(:code).uniq %>
+    </div>
+
+    <div class="field mb-4">
+      <%= form.label :channel_code, class: "block text-sm text-gray-500 mb-1" %>
+      <%= form.select :channel_code, [["line", "line"], ["facebook", "fb"]] %>
+    </div>
+
+    <div class="field mb-4">
+      <%= form.label :amount, class: "block text-sm text-gray-500 mb-1" %>
+      <%= form.number_field :amount, required: "required" %>
+    </div>
+
+    <div>
+      <input type="hidden" id="sale_person_line_id">
+    </div>
+
+    <div class="field">
+      <%= form.submit "Submit", class: "px-4 py-2 bg-gray-800 text-white cursor-pointer" %>
+    </div>
+  <% end %>
+</section>

--- a/app/views/sale_orders/new.html.erb
+++ b/app/views/sale_orders/new.html.erb
@@ -20,8 +20,10 @@
       <input type="hidden" id="sale_person_line_id">
     </div>
 
-    <div class="field">
+    <div class="field mb-4">
       <%= form.submit "Submit", class: "px-4 py-2 bg-gray-800 text-white cursor-pointer" %>
     </div>
+
+    <div id="error-message"></div>
   <% end %>
 </section>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,7 @@ Rails.application.routes.draw do
   resources :linebot
 
   resources :fake_inputs
+  resources :sale_orders
   resource :dashboard
 
 

--- a/db/migrate/20240225083657_add_user_to_sale.rb
+++ b/db/migrate/20240225083657_add_user_to_sale.rb
@@ -1,0 +1,5 @@
+class AddUserToSale < ActiveRecord::Migration[7.1]
+  def change
+    add_reference :sales, :user, null: false, foreign_key: true
+  end
+end

--- a/db/migrate/20240225085554_add_line_user_id_to_users.rb
+++ b/db/migrate/20240225085554_add_line_user_id_to_users.rb
@@ -1,0 +1,7 @@
+class AddLineUserIdToUsers < ActiveRecord::Migration[7.1]
+  def change
+    add_column :users, :line_user_id, :string
+    add_column :users, :line_display_name, :string
+    add_column :users, :line_picture_url, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_02_24_144849) do
+ActiveRecord::Schema[7.1].define(version: 2024_02_25_085554) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -28,6 +28,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_02_24_144849) do
     t.string "channel_code"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "user_id", null: false
+    t.index ["user_id"], name: "index_sales_on_user_id"
   end
 
   create_table "users", force: :cascade do |t|
@@ -39,8 +41,12 @@ ActiveRecord::Schema[7.1].define(version: 2024_02_24_144849) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "role", default: "user", null: false
+    t.string "line_user_id"
+    t.string "line_display_name"
+    t.string "line_picture_url"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "sales", "users"
 end


### PR DESCRIPTION
- User (sale_person) who login to dashboard can create sale order via /sale_orders/new
- Add web form for sale order
- The sale record can be created successfully when user submit the form (happy case)
- Other user who login and stay at dashboard can see the amount update according ActionCable broadcast